### PR TITLE
Add argument descriptions to save() method docs

### DIFF
--- a/base-orm-service-1/service-methods/saving-entities/save.md
+++ b/base-orm-service-1/service-methods/saving-entities/save.md
@@ -10,10 +10,10 @@ Save an entity using hibernate transactions or not. You can optionally flush the
 
 | Key | Type | Required | Default | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| entity | any | Yes | --- |  |
-| forceInsert | boolean | No | false |  |
-| flush | boolean | No | false |  |
-| transactional | boolean | No | true | Use ColdFusion transactions or not |
+| entity | any | Yes | --- | The entity to save |
+| forceInsert | boolean | No | false | Insert as new record whether it already exists or not | 
+| flush | boolean | No | false | Do a flush after saving the entity, false by default since we use transactions |
+| transactional | boolean | No | true | Wrap the save in a ColdFusion transaction |
 
 ## Examples
 


### PR DESCRIPTION
I think descriptions of these arguments help users know what they are for, even if they are "obvious".