### PR TITLE
Typo in criteria queries .ilike()

### DIFF
--- a/criteria-queries/coldbox-criteria-builder/results.md
+++ b/criteria-queries/coldbox-criteria-builder/results.md
@@ -60,8 +60,8 @@ var results = c
      .like("name", "lui%")
      .list();
 
-// Count via projections of all users that start with the letter 'L'
-var count = c.like("name","L%").count();
+// Count via projections of all users that start with the letter 'L' or 'l' using case-insensitive-like
+var count = c.ilike("name","L%").count();
 
 ```
 

--- a/criteria-queries/coldbox-criteria-builder/results.md
+++ b/criteria-queries/coldbox-criteria-builder/results.md
@@ -49,7 +49,9 @@ Once you have concatenated criterias together, you can execute the query via the
       <td style="text-align:left">Execute the criterias and give you the results.</td>
     </tr>
   </tbody>
-</table>```javascript
+</table>
+
+```javascript
 // Get
 var results = c.idEq( 4 ).get();
 
@@ -59,7 +61,7 @@ var results = c
      .list();
 
 // Count via projections of all users that start with the letter 'L'
-var count = c.ilike("name","L%").count();
+var count = c.like("name","L%").count();
 
 ```
 


### PR DESCRIPTION
It should be `c.like()`, not `c.ilike()`.

Also fixed what looks like malformed output in Github markdown viewer - needed extra space, i think.