### PR TITLE
Add documentation for populateFrom* functions

### DIFF
--- a/base-orm-service-1/service-methods/creation-population/populate.md
+++ b/base-orm-service-1/service-methods/creation-population/populate.md
@@ -18,7 +18,7 @@ Populate an entity with a structure of name-value pairs. Make sure the names of 
 | exclude | string | No |  | A list of keys to exclude from the population |
 | nullEmptyInclude | string | No |  | A list of keys to NULL when empty, specifically for ORM population. You can also specify "\*" for all fields |
 | nullEmptyExclude | string | No |  | A list of keys to NOT NULL when empty, specifically for ORM population. You can also specify "\*" for all fields |
-| composeRelationships | boolean | No | true | When true, will automtically attempt to compose relationships from memento |
+| composeRelationships | boolean | No | true | When true, will automatically attempt to compose relationships from memento |
 
 > **INFO** With composeRelationships=true, you can populate one-to-many, many-to-one, many-to-many, and one-to-one relationships from property values in the memento. For 'many-to-one' and 'one-to-one' relationships, the value of the property in the memento should be a single value of the primary key of the target entity to be loaded. For 'one-to-many' and 'many-to-many' relationships, the value of the property in the memento should a comma-delimited list or array of the primary keys of the target entities to be loaded.
 

--- a/base-orm-service-1/service-methods/creation-population/populatefromjson.md
+++ b/base-orm-service-1/service-methods/creation-population/populatefromjson.md
@@ -16,6 +16,9 @@ Populate an entity with a JSON structure packet. Make sure the names of the prop
 | trustedSetter | Boolean | No | false | Do not check if the setter exists, just call it, great for usage with onMissingMethod\(\) and virtual properties |
 | include | string | No |  | A list of keys to ONLY include in the population |
 | exclude | string | No |  | A list of keys to exclude from the population |
+| nullEmptyInclude | string | No |  | A list of keys to NULL when empty, specifically for ORM population. You can also specify "\*" for all fields |
+| nullEmptyExclude | string | No |  | A list of keys to NOT NULL when empty, specifically for ORM population. You can also specify "\*" for all fields |
+| composeRelationships | boolean | No | true | When true, will automatically attempt to compose relationships from memento |
 
 ## Examples
 

--- a/base-orm-service-1/service-methods/creation-population/populatefromquery.md
+++ b/base-orm-service-1/service-methods/creation-population/populatefromquery.md
@@ -17,6 +17,9 @@ Populate an entity with a query object. Make sure the names of the columns match
 | trustedSetter | Boolean | No | false | Do not check if the setter exists, just call it, great for usage with onMissingMethod\(\) and virtual properties |
 | include | string | No | --- | A list of columns to ONLY include in the population |
 | exclude | string | No | --- | A list of columns to exclude from the population |
+| nullEmptyInclude | string | No |  | A list of keys to NULL when empty, specifically for ORM population. You can also specify "\*" for all fields |
+| nullEmptyExclude | string | No |  | A list of keys to NOT NULL when empty, specifically for ORM population. You can also specify "\*" for all fields |
+| composeRelationships | boolean | No | true | When true, will automatically attempt to compose relationships from memento |
 
 ## Examples
 

--- a/base-orm-service-1/service-methods/creation-population/populatefromxml.md
+++ b/base-orm-service-1/service-methods/creation-population/populatefromxml.md
@@ -17,6 +17,9 @@ Populate an entity with an XML packet. Make sure the names of the elements match
 | trustedSetter | Boolean | No | false | Do not check if the setter exists, just call it, great for usage with onMissingMethod\(\) and virtual properties |
 | include | string | No |  | A list of keys to ONLY include in the population |
 | exclude | string | No |  | A list of keys to exclude from the population |
+| nullEmptyInclude | string | No |  | A list of keys to NULL when empty, specifically for ORM population. You can also specify "\*" for all fields |
+| nullEmptyExclude | string | No |  | A list of keys to NOT NULL when empty, specifically for ORM population. You can also specify "\*" for all fields |
+| composeRelationships | boolean | No | true | When true, will automatically attempt to compose relationships from memento |
 
 ## Examples
 


### PR DESCRIPTION
Document 
* `nullEmptyInclude`, 
* `nullEmptyExclude`, and
* `composeRelationships` 

arguments for the

* `populateFromJSON()`,
* `populateFromXML()`, and
* `populateFromQuery()` 

functions 
Makes the [populateFromJSON docs](https://coldbox-orm.ortusbooks.com/base-orm-service-1/service-methods/creation-population/populatefromjson), for example, match the [populate() docs](https://coldbox-orm.ortusbooks.com/base-orm-service-1/service-methods/creation-population/populate).

Also a tiny `automtically` typo fix.