### PR TITLE
Added missing cborm coldbox interception events

### DIFF
--- a/orm-events/coldbox-orm-event-handler/README.md
+++ b/orm-events/coldbox-orm-event-handler/README.md
@@ -47,6 +47,10 @@ Below are the new interception points the ORM Event Handler exposes with the app
 | `ORMPostUpdate` | `{entity}` | Called via the `postUpdate()` event |
 | `ORMPreInsert` | `{entity}` | Called via the `preInsert()` event |
 | `ORMPostInsert` | `{entity}` | Called via the `postInsert()` event |
+| `ORMPreSave` | `{entity}` | Called via the `preSave()` event |
+| `ORMPostSave` | `{entity}` | Called via the `postSave()` event |
+| `ORMPreFlush` | `{entity}` | Called before the Hibernate session is flushed. Triggered via the `preFlush()` event |
+| `ORMPostFlush` | `{entity}` | Called after the Hibernate session is flushed. Triggered via the `postFlush()` event |
 
 With the exposure of these interception points to your ColdBox application, you can easily create decoupled executable chains of events that respond to ORM events. This really expands the ORM interceptor capabilities to a more decoupled way of listening to ORM events. You can even create different interceptors for different ORM entity classes that respond to the same events, extend the entities with AOP, change entities at runtime, and more; how cool is that.
 

--- a/orm-events/coldbox-orm-event-handler/event-handler-cfc.md
+++ b/orm-events/coldbox-orm-event-handler/event-handler-cfc.md
@@ -11,69 +11,20 @@ component extends="cborm.models.EventHandler"{
 
 That's it! Just by doing this the CF ORM will call your CFC's event methods in this CFC and satisfy the interface. Of course you can override the methods, but always remember to fire off the parent class methods in order for the ColdBox interceptions to still work. You can then override each event method as needed. Below is a chart of methods you can override:
 
-<table>
-  <thead>
-    <tr>
-      <th style="text-align:left">Listener Method</th>
-      <th style="text-align:left">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td style="text-align:left"><code>postNew(entity)</code>
-      </td>
-      <td style="text-align:left">This method is called by the ColdBox Base ORM Service Layers after a new
-        entity has been created via its new() method.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><code>preLoad(entity)</code>
-      </td>
-      <td style="text-align:left">This method is called before the load operation or before the data is
-        loaded from the database.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><code>postLoad(entity)</code>
-      </td>
-      <td style="text-align:left">This method is called after the load operation is complete.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><code>preInsert(entity)</code>
-      </td>
-      <td style="text-align:left">This method is called just before the object is inserted.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><code>postInsert(entity)</code>
-      </td>
-      <td style="text-align:left">This method is called after the insert operation is complete.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">
-        <p><code>preUpdate(</code>
-        </p>
-        <p><code>struct oldData,entity</code>
-        </p>
-        <p><code>)</code>
-        </p>
-      </td>
-      <td style="text-align:left">This method is called just before the object is updated. A struct of old
-        data is passed to this method to know the original state of the entity
-        being updated.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><code>postUpdate(entity)</code>
-      </td>
-      <td style="text-align:left">This method is called after the update operation is complete.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><code>preDelete(entity)</code>
-      </td>
-      <td style="text-align:left">This method is called before the object is deleted.</td>
-    </tr>
-    <tr>
-      <td style="text-align:left"><code>postDelete(entity)</code>
-      </td>
-      <td style="text-align:left">This method is called after the delete operation is complete.</td>
-    </tr>
-  </tbody>
-</table>The base event handler CFC you inherit from has all the ColdBox interaction capabilities you will ever need. You can find out all its methods by referring to the API and looking at that class or by inspecting the ColdBox Proxy class, which is what is used for enabling ColdBox interactions: _coldbox.system.remote.ColdboxProxy_
+| Listener Method | Description |
+| :--- | :--- |
+| `postNew(entity)` | This method is called by the ColdBox Base ORM Service Layers after a new entity has been created via its new() method. |
+| `preLoad(entity)` | This method is called before the load operation or before the data is loaded from the database. |
+| `postLoad(entity)` | This method is called after the load operation is complete. |
+| `preInsert(entity)` | This method is called just before the object is inserted. |
+| `postInsert(entity)` | This method is called after the insert operation is complete. |
+| `preUpdate(struct oldData,entity)` | This method is called just before the object is updated. A struct of old data is passed to this method to know the original state of the entity being updated. |
+| `postUpdate(entity)` | This method is called after the update operation is complete. |
+| `preDelete(entity)` | This method is called before the object is deleted. |
+| `postDelete(entity)` | This method is called after the delete operation is complete. |
+| `preSave(entity)` | This method is called before the save operation. |
+| `postSave(entity)` | This method is called after the save operation is complete. |
+| `preFlush(entity)` | This method is called before the Hibernate session is flushed. |
+| `postFlush(entity)` | This method is called after the Hibernate session is flushed. |
 
+The base event handler CFC you inherit from has all the ColdBox interaction capabilities you will ever need. You can find out all its methods by referring to the API and looking at that class or by inspecting the ColdBox Proxy class, which is used for enabling ColdBox interactions: _coldbox.system.remote.ColdboxProxy_


### PR DESCRIPTION
Missing documentation for these cborm interception events: `ORMPreSave`, `ORMPostSave`, `ORMPreFlush`, and `ORMPostFlush`.