### PR TITLE
Add warning about reserved operator names in ACF

### DIFF
--- a/base-orm-service-1/service-methods/criteria-queries/getrestrictions.md
+++ b/base-orm-service-1/service-methods/criteria-queries/getrestrictions.md
@@ -19,3 +19,6 @@ var users = ormService.newCriteria("User")
     .list();
 ```
 
+{% hint style="warning" %}
+Adobe ColdFusion will throw an "Invalid CFML construct" for certain CBORM methods that match [reserved operator names](https://helpx.adobe.com/coldfusion/developing-applications/the-cfml-programming-language/elements-of-cfml/reserved-words-in-coldfusion.html), such as `.and()`, `.or()`, and `.eq()`. To avoid these errors and build cross-engine compatible code, use `.$and()`, `.$or()`, and `.isEq()`.
+{% endhint %}

--- a/criteria-queries/coldbox-criteria-builder/restrictions/README.md
+++ b/criteria-queries/coldbox-criteria-builder/restrictions/README.md
@@ -67,6 +67,10 @@ To build our criteria queries we will mostly use the methods in the criteria obj
 | `isTrue(required string property)` | Returns if the property is true | _c.isTrue\("isPublished"\);_ |
 
 {% hint style="info" %}
+Adobe ColdFusion may throw an "Invalid CFML construct" error for certain CBORM methods that match [reserved operator names](https://helpx.adobe.com/coldfusion/developing-applications/the-cfml-programming-language/elements-of-cfml/reserved-words-in-coldfusion.html), such as `.and()`, `.or()`, and `.eq()`. You can use `.$and()`, `.$or()`, and `.isEq()` to avoid these errors and build cross-engine compatible code.
+{% endhint %}
+
+{% hint style="info" %}
 In some cases \(`isEq(), isIn(),` etc\), you may receive data type mismatch errors. These can be resolved by using JavaCast on your criteria value or use our auto caster methods: `idCast(), autoCast()`
 {% endhint %}
 


### PR DESCRIPTION
I added a warning to the CBORM docs based on a discussion w/ Luis about reserved operator names in ACF. Evidently ACF (2018, in my experience) throws an "invalid cfml structure" error upon encountering these method names.

I will attempt to update this PR with more commits for other instances of documentation for the `.or()`, `.and()`, `.eq()` methods.